### PR TITLE
fix: add dates and archival points and remove unused names

### DIFF
--- a/names.md
+++ b/names.md
@@ -1,25 +1,18 @@
-+ Scales         | ????-??-??
-+ Rails          | ????-??-??
-+ Hatsu/Okemia   | ????-??-??
-+ Ayaka Chat?    | ????-??-??
-+ Rails          | ????-??-??
-
- | No. | Name      | Date with link                                                                                              |
-|:---:|:----------|:------------------------------------------------------------------------------------------------------------|
-|  1  | Vercal    | [2022-03-13](https://github.com/decker-archive/api/commit/050074b9ac3da41eb4852877b1ab46a0915c8817)         |
-|  2  | Factions  | [2022-03-23](https://canary.discord.com/channels/881118111967883295/881118112492191796/956182155191550003)  |
-|  3  | Concord   | [2022-04-13](https://canary.discord.com/channels/881118111967883295/881118112492191796/963795519711367168)  |
-|  4  | Redux     | [2022-05-03](https://canary.discord.com/channels/881118111967883295/969836504128036864/970955845695324190)  |
-|  5  | Neoform   | [2022-05-19](https://canary.discord.com/channels/881118111967883295/969836504128036864/976866951693488168)  |
-|  6  | Mastadon  | [2022-05-23](https://canary.discord.com/channels/881118111967883295/881118112492191796/978299567256797234)  | 
-|  7  | Venera    | [2022-05-25](https://canary.discord.com/channels/962194292296802334/962194292296802337/979015020316868669)  | 
-|  8  | Gozzle    | [2022-06-18](https://canary.discord.com/channels/962194292296802334/962194292296802337/987741307214630982)  |
-|  9  | Anavereum | [2022-06-22](https://canary.discord.com/channels/881118111967883295/969836504128036864/989019044403368027)  |
-| 10  | Plufify   | [2022-07-09](https://canary.discord.com/channels/881118111967883295/969836504128036864/995257991018332250)  |
-| 11  | Stancium  | [2022-07-09](https://canary.discord.com/channels/881118111967883295/969836504128036864/995287597809156216)  |
-| 12  | Derailed  | [2022-07-14](https://canary.discord.com/channels/881118111967883295/969836504128036864/997095149429592154)  |
-| 13  | Docked    | [2022-08-07](https://canary.discord.com/channels/881118111967883295/881118112492191796/1005799500956323861) |
-| 14  | Discend   | [2022-08-09](https://canary.discord.com/channels/962194292296802334/988243874201862144/1006538875981799484) |
-| 15  | snuxapp   | [2022-08-11](https://canary.discord.com/channels/962194292296802334/988243874201862144/1007175454622490705) |
-| 16  | Couchhub  | [2022-08-13](https://github.com/deckerapp/decker-api/commit/ec2e9e191c3f599d1c4fbd8e8736be458967c487)       |
-| 17  | Decker    | [2022-08-14](https://canary.discord.com/channels/881118111967883295/881118112492191796/1008365526726226060) |
++ Venera | 2022-05-25 ([Archive](https://canary.discord.com/channels/881118111967883295/969836504128036864/979011865524965377))
++ Plufify | 2022-07-9 ([Archive](https://github.com/decker-archive/backend/commit/b174d2af013095bce4d06961e25f3e268b013b6f))
++ Derailed | First appeared on 2022-07-05 last appeared 2022-08-05 ([Archive](https://github.com/decker-archive/backend/commit/7b6c9420a0267762e040e9a541f29a5747f96dcd))
++ Neoform | 2022-05-19 ([Archive](https://github.com/concordchat/concord-api/commit/6c8003a077145dd9ae383b9b513fd685e6c2f066))
++ Scales | 2022-04-30 ([Archive](https://canary.discord.com/channels/881118111967883295/881118112492191796/969865722991869982))
++ Factions | 2022-03-21 ([Archive](https://github.com/concordchat/concord-api/commit/e539f7191fe8d70f9f8a77fb9a1b973541617a46))
++ Rails | 2022-03-17 ([Archive](https://github.com/decker-archive/api))
++ Vercal | 2022-03-13 ([Archive](https://github.com/decker-archive/api/commit/050074b9ac3da41eb4852877b1ab46a0915c8817))
++ Hatsu/Okemia (These names were used interchangably) | 2022-02-17 ([Archive](https://github.com/decker-archive/api/commit/bf0549264018319595e10b393a5762334cc4f31a))
++ Stancium | 2021-12-08 ([Archive](https://github.com/decker-archive/api/commit/d37cab03ecc9ce0c4343052464a8006837c2bbe6))
++ Mastadon | 2022-05-23 ([Archive](https://canary.discord.com/channels/881118111967883295/881118112492191796/978299567256797234))
++ Concord | First appeared on 2022-04-13 last appeared 2022-05-23 ([Archive](https://canary.discord.com/channels/881118111967883295/881118112492191796/963795519711367168))
++ Redux | 2022-05-02 and 2022-08-12 ([Archive](https://canary.discord.com/channels/881118111967883295/969836504128036864/970696288574271533))
++ Docked | 2022-08-07 ([Archive](https://canary.discord.com/channels/881118111967883295/881118112492191796/1005799500956323861))
++ Snux | 2022-08-11 ([Archive](https://canary.discord.com/channels/881118111967883295/969836504128036864/1007184909632282684))
++ Couchhub | 2022-08-13 ([Archive](https://github.com/deckerapp/decker-api/commit/ec2e9e191c3f599d1c4fbd8e8736be458967c487))
++ Decker | 2022-08-14 ([Archive](https://canary.discord.com/channels/881118111967883295/881118112492191796/1008358169594048532))
++ Ayaka | 2022-03-12 ([Archive](https://github.com/concordchat/api-docs/commit/ea8034a983003808c6df91c6c49cc21e8f72d858))


### PR DESCRIPTION
- Gozzle was never used for the chat app's name
- Anavereum was never used for the chat app's name

Not sure if this is everything.