### PR TITLE
fix: remove Telescope

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,3 @@ The rather turbulent name history of a chat app made by vincent.
 | 17  | Snux         | [2022-08-11](https://canary.discord.com/channels/962194292296802334/988243874201862144/1007175454622490705) |
 | 18  | Couchhub     | [2022-08-13](https://github.com/deckerapp/decker-api/commit/ec2e9e191c3f599d1c4fbd8e8736be458967c487)       |
 | 19  | Decker       | [2022-08-14](https://canary.discord.com/channels/881118111967883295/881118112492191796/1008358169594048532) |
-| 20  | Telescope    | [2022-08-17](https://prnt.sc/vKodrdgCix6M)                                                                  |


### PR DESCRIPTION
telescope was the name of Decker's/Derailed's sucessor, Itch.